### PR TITLE
searchStudentのテストについて

### DIFF
--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -4,12 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Schema(description = "受講生情報")
 @Getter
 @Setter
+@EqualsAndHashCode(of = {"id"})  //比較する際idだけをみる
 public class Student {
 
  @NotBlank

--- a/src/main/java/raisetech/student/management/domain/StudentDetail.java
+++ b/src/main/java/raisetech/student/management/domain/StudentDetail.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,6 +16,7 @@ import raisetech.student.management.data.StudentCourse;
 @Setter
 @NoArgsConstructor //引数を使わないコンストラクター
 @AllArgsConstructor  //全項目を設定するコンストラクター
+@EqualsAndHashCode(of = {"student"}) //比較する際studentだけをみる
 public class StudentDetail {
 
   @Schema(description = "受講生詳細情報")

--- a/src/test/java/raisetech/student/management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceTest.java
@@ -3,11 +3,9 @@ package raisetech.student.management.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,15 +60,15 @@ class StudentServiceTest {
     List<StudentCourse> studentCourse = new ArrayList<>();
 
     Mockito.when(repository.searchStudent(id)).thenReturn(student);
-    Mockito.when(repository.searchStudentCourse(student.getId())).thenReturn(studentCourse);
+    Mockito.when(repository.searchStudentCourse(id)).thenReturn(studentCourse);
 
     StudentDetail expected = new StudentDetail(student,studentCourse);
     StudentDetail actual =  sut.searchStudent(id);
 
     verify(repository,times(1)).searchStudent(id);
-    verify(repository,times(1)).searchStudentCourse(student.getId());
+    verify(repository,times(1)).searchStudentCourse(id);
 
-    assertEquals(expected.getStudent().getId(), actual.getStudent().getId());
+    assertEquals(expected , actual);
   }
 
   @Test  //registerStudent


### PR DESCRIPTION
## 確認内容
等値、同一性  (==)→参照(アドレス)が同じ
等価、同値性  (equals())→中身の内容(値)が同じ、参照は違ってもＯＫ
デフォルトでは Object.equals() は等値だから
自分で equals() メソッドをオーバーライドすれば、name , id など中身の比較(等価)に変えらる。
今回idが同じか検証してみているので、equals() メソッドをオーバーライドしたら
assertEquals(expected, actual);
で比較したときに、参照ではなくidが同じか検証してくれる。


また、中身が同じなら、参照が違っても同じとして見られるように
equals()とhashCode()はセットで実装する。
（中身が同じでも参照が違う場合がある為）
Lombokを使用してるので@EqualsAndHashCodeアノテーションをつかって
studentDetailと、studentにアノテーションを実装

studentDetailクラスに
@EqualsAndHashCode(of = {"student"})
(studentDetailの比較するならstudnetと同じかどうかみる)
↓
studentクラスに
@EqualsAndHashCode(of = {"id"}) 
（studentの比較をするならIDが一緒かどうかみる）

あくまでもstudentIDと一緒かどうかみたいから
studentcourseにはなにも書かない。

＊(of = {"id"}) を記載した理由は、今回のプロジェクトのなかで比較するときに
idをもとに比較することがほとんどな為。
searchStudentでしかidの比較を使用しないなら、
assertEquals(expected.getId(), actual.getId());
と書けばＯＫ

これでassertEquals(expected, actual);
を実装したときに、idをみて比較される。

といった流れであってますでしょうか？
