### PR TITLE
StudentConverterのテスト実装

### DIFF
--- a/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
@@ -1,24 +1,28 @@
 package raisetech.student.management.controller.converter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 import raisetech.student.management.domain.StudentDetail;
 
-@ExtendWith(MockitoExtension.class)
 class StudentConverterTest {
 
   private StudentConverter sut;
 
+  @BeforeEach
+  void before(){
+    sut = new  StudentConverter();
+  }
+
   @Test
   void StudentIdが一致する受講生詳細とコース情報が取れてくること(){
-    sut = new StudentConverter();
     String id = "999";
 
     Student student = new Student();
@@ -42,6 +46,66 @@ class StudentConverterTest {
     //検証
     assertEquals(actual , expected);
 
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡して受講生詳細のリストが作成出来る事() {
+    Student student = new Student();
+    student.setId("1");
+    student.setName("林田耕太");
+    student.setFurigana("ハヤシダコウタ");
+    student.setNickname("はやしだ");
+    student.setMail("hayasida@gmail.com");
+    student.setRegion("草加市");
+    student.setAge(41);
+    student.setGender("男");
+    student.setRemark("");
+    student.setDeleted(false);
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId("1");
+    studentCourse.setStudentsId("1");
+    studentCourse.setCoursesName("Javaコース");
+    studentCourse.setStart(LocalDateTime.now());
+    studentCourse.setEnd(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList,studentCourseList);
+
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEqualTo(studentCourseList);
+  }
+
+  @Test
+  void 受講生のリストと受講生コース情報のリストを渡した時に紐づかない受講生コース情報は除外される事() {
+    Student student = new Student();
+    student.setId("1");
+    student.setName("林田耕太");
+    student.setFurigana("ハヤシダコウタ");
+    student.setNickname("はやしだ");
+    student.setMail("hayasida@gmail.com");
+    student.setRegion("草加市");
+    student.setAge(41);
+    student.setGender("男");
+    student.setRemark("");
+    student.setDeleted(false);
+
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId("1");
+    studentCourse.setStudentsId("1");
+    studentCourse.setCoursesName("Javaコース");
+    studentCourse.setStart(LocalDateTime.now());
+    studentCourse.setEnd(LocalDateTime.now().plusYears(1));
+
+    List<Student> studentList = List.of(student);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+
+    List<StudentDetail> actual = sut.convertStudentDetails(studentList,studentCourseList);
+
+    assertThat(actual.get(0).getStudent()).isEqualTo(student);
+    assertThat(actual.get(0).getStudentCourseList()).isEmpty();
   }
 
 }


### PR DESCRIPTION
## 実装内容
- StudentConverterのテスト
- 受講生詳細と、studentIdに紐づくコース情報が取れる事の検証を行いました。

## 動作確認
###テスト結果
<img width="1790" height="955" alt="スクリーンショット 2025-07-29 155643" src="https://github.com/user-attachments/assets/3408db2e-c718-42b8-aedc-220126436e02" />


## 工夫した点・学んだこと
controllerのテストの際@EqualsAndHashCodeをstudent、studentCourse、studentDetailそれぞれに付与していたので
assertEquals(actual , expected);　で中身の比較ができました。