### PR TITLE
申し込み情報ごとの検索機能

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -17,11 +17,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.student.management.data.StudentInfo;
-import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
 /**
-受講生の検索や登録、更新などを行うREST APIとして実行されるcontrollerです
+ 受講生の検索や登録、更新などを行うREST APIとして実行されるcontrollerです
  *
  */
 
@@ -41,8 +40,8 @@ public class StudentController {
    *
    * @return 受講生詳細一覧（全件）
    */
-  @Operation(summary = "一覧検索" , description = "受講生の一覧を検索します。")
-  @ApiResponse(responseCode = "200",description = "登録が完了しました。")
+  @Operation(summary = "一覧検索", description = "受講生の一覧を検索します。")
+  @ApiResponse(responseCode = "200", description = "登録が完了しました。")
   @GetMapping("/studentList")
   public List<StudentInfo> getStudentList() {
     return service.searchStudentList();
@@ -54,7 +53,7 @@ public class StudentController {
    * @param id 受講生ID
    * @return 受講生
    */
-  @Operation(summary = "ID検索" , description = "受講生IDをもとに受講生情報を検索します。")
+  @Operation(summary = "ID検索", description = "受講生IDをもとに受講生情報を検索します。")
   @ApiResponse(responseCode = "200", description = "登録が完了しました。")
 
   @GetMapping("/student/{id}")
@@ -65,14 +64,15 @@ public class StudentController {
 
   /**
    * 受講生詳細検索です。申し込み情報に紐づくコース情報、受講生詳細を取得します。
+   *
    * @param status 申し込み情報
    * @return 受講生詳細、コース情報、申し込み情報
    */
-  @Operation(summary = "申し込み情報検索" , description = "受講生申し込み情報をもとに対象の受講生詳細を検索します。")
+  @Operation(summary = "申し込み情報検索", description = "受講生申し込み情報をもとに対象の受講生詳細を検索します。")
   @GetMapping("/student")
-  public List<StudentInfo> getStudentInfo(@RequestParam String status){
+  public List<StudentInfo> getStudentInfo(@RequestParam String status) {
     return service.searchStudentAppStatus(status);
-}
+  }
 
   /**
    * 受講生詳細の登録を行います
@@ -82,10 +82,10 @@ public class StudentController {
    */
 
 
-  @Operation(summary = "受講生登録" , description = "受講生を登録します。")
-  @ApiResponse(responseCode = "200",description = "登録が完了しました。")
+  @Operation(summary = "受講生登録", description = "受講生を登録します。")
+  @ApiResponse(responseCode = "200", description = "登録が完了しました。")
   @PostMapping("/registerStudent")
-  public ResponseEntity <StudentInfo> registerStudent(@RequestBody @Valid StudentInfo studentInfo) {
+  public ResponseEntity<StudentInfo> registerStudent(@RequestBody @Valid StudentInfo studentInfo) {
     StudentInfo responseStudentInfo = service.registerStudent(studentInfo);
     return ResponseEntity.ok(responseStudentInfo);
   }
@@ -96,10 +96,11 @@ public class StudentController {
    * @param studentInfoList 受講生詳細
    * @return 実行結果
    */
-  @Operation(summary = "受講生詳細更新" , description = "受講生の詳細情報を更新します。")
-  @ApiResponse(responseCode = "200",description = "登録が完了しました。")
+  @Operation(summary = "受講生詳細更新", description = "受講生の詳細情報を更新します。")
+  @ApiResponse(responseCode = "200", description = "登録が完了しました。")
   @PutMapping("/updateStudent") //更新内容を入力するところ
-  public ResponseEntity<String> updateStudent(@RequestBody @Valid List<StudentInfo>studentInfoList) {
+  public ResponseEntity<String> updateStudent(
+      @RequestBody @Valid List<StudentInfo> studentInfoList) {
     service.updateStudent(studentInfoList);
     return ResponseEntity.ok("更新が成功しました");
   }

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -44,7 +44,7 @@ public class StudentController {
   @Operation(summary = "一覧検索" , description = "受講生の一覧を検索します。")
   @ApiResponse(responseCode = "200",description = "登録が完了しました。")
   @GetMapping("/studentList")
-  public List<StudentDetail> getStudentList() {
+  public List<StudentInfo> getStudentList() {
     return service.searchStudentList();
   }
 
@@ -58,7 +58,7 @@ public class StudentController {
   @ApiResponse(responseCode = "200", description = "登録が完了しました。")
 
   @GetMapping("/student/{id}")
-  public StudentDetail getStudent(
+  public List<StudentInfo> getStudent(
       @PathVariable @Min(1) int id) {
     return service.searchStudent(id);
   }
@@ -77,7 +77,7 @@ public class StudentController {
   /**
    * 受講生詳細の登録を行います
    *
-   * @param studentDetail 受講生詳細
+   * @param studentInfo 受講生詳細
    * @return 実行結果
    */
 
@@ -85,22 +85,22 @@ public class StudentController {
   @Operation(summary = "受講生登録" , description = "受講生を登録します。")
   @ApiResponse(responseCode = "200",description = "登録が完了しました。")
   @PostMapping("/registerStudent")
-  public ResponseEntity<StudentDetail> registerStudent(@RequestBody @Valid StudentDetail studentDetail) {
-    StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
-    return ResponseEntity.ok(responseStudentDetail);
+  public ResponseEntity <StudentInfo> registerStudent(@RequestBody @Valid StudentInfo studentInfo) {
+    StudentInfo responseStudentInfo = service.registerStudent(studentInfo);
+    return ResponseEntity.ok(responseStudentInfo);
   }
 
   /**
    * 受講生詳細の更新を行います。 キャンセルフラグの更新もここで行います(論理削除)
    *
-   * @param studentDetail 受講生詳細
+   * @param studentInfoList 受講生詳細
    * @return 実行結果
    */
   @Operation(summary = "受講生詳細更新" , description = "受講生の詳細情報を更新します。")
   @ApiResponse(responseCode = "200",description = "登録が完了しました。")
   @PutMapping("/updateStudent") //更新内容を入力するところ
-  public ResponseEntity<String> updateStudent(@RequestBody @Valid StudentDetail studentDetail) {
-    service.updateStudent(studentDetail);
+  public ResponseEntity<String> updateStudent(@RequestBody @Valid List<StudentInfo>studentInfoList) {
+    service.updateStudent(studentInfoList);
     return ResponseEntity.ok("更新が成功しました");
   }
 

--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -14,7 +14,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.student.management.data.StudentInfo;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.service.StudentService;
 
@@ -60,6 +62,17 @@ public class StudentController {
       @PathVariable @Min(1) int id) {
     return service.searchStudent(id);
   }
+
+  /**
+   * 受講生詳細検索です。申し込み情報に紐づくコース情報、受講生詳細を取得します。
+   * @param status 申し込み情報
+   * @return 受講生詳細、コース情報、申し込み情報
+   */
+  @Operation(summary = "申し込み情報検索" , description = "受講生申し込み情報をもとに対象の受講生詳細を検索します。")
+  @GetMapping("/student")
+  public List<StudentInfo> getStudentInfo(@RequestParam String status){
+    return service.searchStudentAppStatus(status);
+}
 
   /**
    * 受講生詳細の登録を行います

--- a/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentAppStatus;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentInfo;
 import raisetech.student.management.domain.StudentDetail;
 
 
@@ -43,20 +44,27 @@ public class StudentConverter {
     });
     return studentDetails;
   }
-  public List<StudentDetail> convertCourseStatus(List<StudentDetail> studentDetails,
-      List<StudentAppStatus> studentAppStatusList){
   //コース情報と申し込み情報の紐づけ
-    Map<Integer,StudentAppStatus> studentAppStatusMap = new HashMap<>();
-    for(StudentAppStatus studentAppstatus : studentAppStatusList){
-      studentAppStatusMap.put(studentAppstatus.getStudentCourseId(),studentAppstatus);
+  public List<StudentInfo> convertStudentInfo(List<StudentDetail> studentDetails,
+      List<StudentAppStatus> studentAppStatusList) {
+    Map<Integer, StudentAppStatus> studentAppStatusMap = new HashMap<>();
+    for (StudentAppStatus studentAppstatus : studentAppStatusList) {
+      studentAppStatusMap.put(studentAppstatus.getStudentCourseId(), studentAppstatus);
     }
+    List<StudentInfo>studentInfoList = new ArrayList<>();
+    for (StudentDetail studentDetail : studentDetails) {
+      for (StudentCourse studentCourse : studentDetail.getStudentCourseList()) {
+        StudentAppStatus studentAppStatus = studentAppStatusMap.get(studentCourse.getId());
 
-    studentDetails.stream().flatMap(studentDetail -> studentDetail.getStudentCourseList().stream())
-        .forEach(studentCourse -> {
-          StudentAppStatus studentAppStatus = studentAppStatusMap.get(studentCourse.getId());
-          studentCourse.setStatus(studentAppStatus);
-        });
-  return studentDetails;
+        StudentInfo studentInfo = new StudentInfo();
+        studentInfo.setStudent(studentDetail.getStudent());
+        studentInfo.setStudentCourse(studentCourse);
+        studentInfo.setStudentAppStatus(studentAppStatus);
+
+        studentInfoList.add(studentInfo);
+      }
+    }
+    return studentInfoList;
   }
   }
 

--- a/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
@@ -44,6 +44,7 @@ public class StudentConverter {
     });
     return studentDetails;
   }
+
   //コース情報と申し込み情報の紐づけ
   public List<StudentInfo> convertStudentInfo(List<StudentDetail> studentDetails,
       List<StudentAppStatus> studentAppStatusList) {
@@ -51,7 +52,7 @@ public class StudentConverter {
     for (StudentAppStatus studentAppstatus : studentAppStatusList) {
       studentAppStatusMap.put(studentAppstatus.getStudentCourseId(), studentAppstatus);
     }
-    List<StudentInfo>studentInfoList = new ArrayList<>();
+    List<StudentInfo> studentInfoList = new ArrayList<>();
     for (StudentDetail studentDetail : studentDetails) {
       for (StudentCourse studentCourse : studentDetail.getStudentCourseList()) {
         StudentAppStatus studentAppStatus = studentAppStatusMap.get(studentCourse.getId());
@@ -66,5 +67,5 @@ public class StudentConverter {
     }
     return studentInfoList;
   }
-  }
+}
 

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -35,7 +35,4 @@ public class StudentCourse {
   @Schema(description = "受講終了日" , example = "2025.09.01")
   private LocalDateTime endDate;
 
-  @Schema(description = "申し込み状況" , example = "受講中")
-  @NotNull
-  private StudentAppStatus status;
 }

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -3,7 +3,6 @@ package raisetech.student.management.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/src/main/java/raisetech/student/management/data/StudentInfo.java
+++ b/src/main/java/raisetech/student/management/data/StudentInfo.java
@@ -1,18 +1,28 @@
 package raisetech.student.management.data;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-@Schema(description = "受講生の全ての情報")
+@Schema(description = "受講生詳細　1受講生：1コース：1申し込み状況")
 @Getter
 @Setter
 @EqualsAndHashCode
 
 public class StudentInfo {
+
+  @Schema(description = "受講生詳細")
+  @Valid
   private Student student;
+
+  @Schema(description = "受講生コース詳細")
+  @Valid
   private StudentCourse studentCourse;
+
+  @Schema(description = "受講生コース申し込み状況")
+  @Valid
   private StudentAppStatus studentAppStatus;
 
 }

--- a/src/main/java/raisetech/student/management/data/StudentInfo.java
+++ b/src/main/java/raisetech/student/management/data/StudentInfo.java
@@ -1,0 +1,18 @@
+package raisetech.student.management.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "受講生の全ての情報")
+@Getter
+@Setter
+@EqualsAndHashCode
+
+public class StudentInfo {
+  private Student student;
+  private StudentCourse studentCourse;
+  private StudentAppStatus studentAppStatus;
+
+}

--- a/src/main/java/raisetech/student/management/domain/StudentDetail.java
+++ b/src/main/java/raisetech/student/management/domain/StudentDetail.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentCourse;
 
-@Schema(description = "受講生詳細")
+@Schema(description = "受講生詳細　1受講生：複数コース：複数申し込み状況")
 @Getter
 @Setter
 @NoArgsConstructor //引数を使わないコンストラクター

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -45,6 +45,7 @@ public interface StudentRepository {
 
   /**
    * 受講生コースの検索を行います。
+   *
    * @param studentCourseId 受講生コースID
    * @return 受講生コース情報
    */
@@ -61,13 +62,14 @@ public interface StudentRepository {
   /**
    * 受講生コースIDに紐づく受講生コース申し込み状況を検索します。
    *
-   * @param StudentCourseId　受講生コースID
+   * @param StudentCourseId 　受講生コースID
    * @return 受講生コースIDに紐づく受講生コース申し込み状況を検索します。
    */
   StudentAppStatus searchStudentStatus(int StudentCourseId);
 
   /**
    * 申し込み情報ひ紐づくコース情報、受講生詳細を検索します。
+   *
    * @param status 申し込み情報
    * @return 申し込み情報に紐づくコース情報と受講生詳細
    */
@@ -115,9 +117,6 @@ public interface StudentRepository {
    * @param StudentAppStatus 受講生コース申し込み状況
    */
   void updateStudentAppStatus(StudentAppStatus StudentAppStatus);
-
-
-
 
 
 }

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -67,6 +67,13 @@ public interface StudentRepository {
   StudentAppStatus searchStudentStatus(int StudentCourseId);
 
   /**
+   * 申し込み情報ひ紐づくコース情報、受講生詳細を検索します。
+   * @param status 申し込み情報
+   * @return 申し込み情報に紐づくコース情報と受講生詳細
+   */
+  List<StudentAppStatus> searchStudentAppStatus(String status);
+
+  /**
    * 受講生を新規登録します。IDに関しては自動採番を行う。
    *
    * @param student 受講生
@@ -110,8 +117,6 @@ public interface StudentRepository {
   void updateStudentAppStatus(StudentAppStatus StudentAppStatus);
 
 
-  //statusごとの検索
-  List<StudentAppStatus> searchStudentAppStatus(String status);
 
 
 

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -44,9 +44,17 @@ public interface StudentRepository {
   List<StudentCourse> searchStudentCourse(int studentId);
 
   /**
+   * 受講生コースの検索を行います。
+   * @param studentCourseId 受講生コースID
+   * @return 受講生コース情報
+   */
+  StudentCourse searchStudentCourseById(int studentCourseId);
+
+
+  /**
    * 受講生のコース申し込み状況の全件検索を行います。
    *
-   * @return 受講生んｐコース申し込み状況(全件)
+   * @return 受講生コース申し込み状況(全件)
    */
   List<StudentAppStatus> searchStatusList();
 

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -25,7 +25,7 @@ public class StudentService {
   private StudentConverter converter;
 
   @Autowired
-  public StudentService(StudentRepository repository, StudentConverter converter){
+  public StudentService(StudentRepository repository, StudentConverter converter) {
     this.repository = repository;
     this.converter = converter;
   }
@@ -40,15 +40,14 @@ public class StudentService {
     List<StudentCourse> studentCourseList = repository.searchStudentCourseList();
     List<StudentAppStatus> studentAppStatusList = repository.searchStatusList();
     //受講生情報とコース情報を紐づけ
-    List<StudentDetail>studentDetails = converter.convertStudentDetails(studentList,studentCourseList);
+    List<StudentDetail> studentDetails = converter.convertStudentDetails(studentList,
+        studentCourseList);
     //コース情報に申し込み状況を紐づけ
-    return converter.convertStudentInfo(studentDetails,studentAppStatusList);
+    return converter.convertStudentInfo(studentDetails, studentAppStatusList);
   }
 
   /**
-   * 受講生詳細検索です。
-   * IDに紐づく受講生情報を取得した後、その受講生に紐づく受講生コース情報を取得して
-   * 更に受講生コース情報に紐づく受講生申し込み情報を設定します。
+   * 受講生詳細検索です。 IDに紐づく受講生情報を取得した後、その受講生に紐づく受講生コース情報を取得して 更に受講生コース情報に紐づく受講生申し込み情報を設定します。
    *
    * @param id 　受講生ID
    * @return 受講生詳細
@@ -57,8 +56,8 @@ public class StudentService {
   public List<StudentInfo> searchStudent(int id) {
     Student student = repository.searchStudent(id);
     List<StudentCourse> studentCourseList = repository.searchStudentCourse(student.getId());
-    List<StudentInfo>studentInfoList = new ArrayList<>();
-    for (StudentCourse studentCourse : studentCourseList){
+    List<StudentInfo> studentInfoList = new ArrayList<>();
+    for (StudentCourse studentCourse : studentCourseList) {
       StudentAppStatus studentAppStatus = repository.searchStudentStatus(studentCourse.getId());
 
       StudentInfo studentInfo = new StudentInfo();
@@ -71,8 +70,7 @@ public class StudentService {
   }
 
   /**
-   * 申し込み情報ごとの検索です。
-   * 申し込み情報からコースIDを取得して後、そのコース情報に紐づく受講生情報を取得します。
+   * 申し込み情報ごとの検索です。 申し込み情報からコースIDを取得して後、そのコース情報に紐づく受講生情報を取得します。
    *
    * @param status 申し込み情報
    * @return 申し込み情報に当てはまる、受講生コース情報と受講生詳細
@@ -97,8 +95,7 @@ public class StudentService {
   }
 
   /**
-   * 受講生詳細の登録を行います。
-   * 受講生と受講生コース情報と申し込み情報を個別に登録し、受講生コース情報には受講生情報を紐づける値やコース開始日、コース終了日を設定します。
+   * 受講生詳細の登録を行います。 受講生と受講生コース情報と申し込み情報を個別に登録し、受講生コース情報には受講生情報を紐づける値やコース開始日、コース終了日を設定します。
    * 受講生申し込み情報には受講生コース情報を紐づける値を設定します。
    *
    * @param studentInfo 受講生詳細
@@ -121,7 +118,7 @@ public class StudentService {
    * 受講生コース情報を登録する際の初期情報を設定します。
    *
    * @param studentCourses 受講生コース情報
-   * @param id       受講生
+   * @param id             受講生
    */
   void initStudentsCourse(StudentCourse studentCourses, int id) {
     LocalDateTime now = LocalDateTime.now();
@@ -137,7 +134,7 @@ public class StudentService {
    * @param studentAppStatus 受講生申し込み情報
    * @param id　受講生
    */
-  void linkCourseToStatus(StudentAppStatus studentAppStatus , int id) {
+  void linkCourseToStatus(StudentAppStatus studentAppStatus, int id) {
     studentAppStatus.setStudentCourseId(id);
   }
 
@@ -147,8 +144,8 @@ public class StudentService {
    * @param studentInfoList 受講生詳細
    */
   @Transactional
-  public void updateStudent(List<StudentInfo>studentInfoList) {
-       for(StudentInfo studentInfo : studentInfoList){
+  public void updateStudent(List<StudentInfo> studentInfoList) {
+    for (StudentInfo studentInfo : studentInfoList) {
       repository.updateStudent(studentInfo.getStudent());
       repository.updateStudentCourse(studentInfo.getStudentCourse());
       repository.updateStudentAppStatus(studentInfo.getStudentAppStatus());

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -1,6 +1,7 @@
 package raisetech.student.management.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import raisetech.student.management.controller.converter.StudentConverter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentAppStatus;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentInfo;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.repository.StudentRepository;
 
@@ -61,6 +63,31 @@ public class StudentService {
       studentCourse.setStatus(studentAppStatus);
     }
     return new StudentDetail(student, studentCourseList);
+  }
+
+  /**
+   * 申し込み情報ごとの検索です。
+   * 申し込み情報からコースIDを取得して後、そのコース情報に紐づく受講生情報を取得します。
+   *
+   * @param status 申し込み情報
+   * @return 申し込み情報に当てはまる、受講生コース情報と受講生詳細
+   */
+  public List<StudentInfo> searchStudentAppStatus(String status) {
+    List<StudentAppStatus> studentAppStatusList = repository.searchStudentAppStatus(status);
+    List<StudentInfo> studentInfoList = new ArrayList<>();
+
+    studentAppStatusList.forEach(studentAppStatus -> {
+      int studentCourseId = studentAppStatus.getStudentCourseId();
+      StudentCourse studentCourse = repository.searchStudentCourseById(studentCourseId);
+      Student student = repository.searchStudent(studentCourse.getStudentsId());
+      StudentInfo info = new StudentInfo();
+      info.setStudent(student);
+      info.setStudentCourse(studentCourse);
+      info.setStudentAppStatus(studentAppStatus);
+      studentInfoList.add(info);
+    });
+    return studentInfoList;
+
   }
 
   /**

--- a/src/main/java/raisetech/student/management/validation/Update.java
+++ b/src/main/java/raisetech/student/management/validation/Update.java
@@ -1,5 +1,7 @@
 package raisetech.student.management.validation;
 
 public class Update {
-
+/*
+  UpDate時にバリデーションを掛けられるようにするクラスです。
+ */
 }

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -56,6 +56,11 @@
     SELECT * FROM student_appstatus WHERE student_course_id= #{studentCourseId}
   </select>
 
+  <!--受講生コースIDに紐づく受講生コース情報を検索-->
+  <select id="searchStudentCourseById" resultType="raisetech.student.management.data.StudentCourse">
+    SELECT * FROM students_courses WHERE id= #{studentCourseId}
+  </select>
+
   <!--statusごとの検索-->
   <select id="searchStudentAppStatus" resultType="raisetech.student.management.data.StudentAppStatus">
     SELECT * FROM student_appstatus WHERE status= #{"status"}

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE  mapper PUBLIC "-//maybatis.org/DTD Mapper 3.0//EN" "http://mybatis.org.dtd/mybatis-3-mapper.dtd">
+<!DOCTYPE  mapper PUBLIC "-//maybatis.org/DTD Mapper 3.0//EN"
+  "http://mybatis.org.dtd/mybatis-3-mapper.dtd">
 <mapper namespace="raisetech.student.management.repository.StudentRepository">
 
   <!--受講生の全件検索-->
   <select id="search" resultType="raisetech.student.management.data.Student">
-  SELECT * FROM students
- </select>
+    SELECT * FROM students
+  </select>
 
   <!--受講生の検索-->
   <select id="searchStudent" resultType="raisetech.student.management.data.Student">
@@ -21,30 +22,6 @@
   <select id="searchStudentCourse" resultType="raisetech.student.management.data.StudentCourse">
     SELECT * FROM students_courses WHERE students_id= #{studentId}
   </select>
-
-
-  <!--受講生を新規登録 -->
-  <insert id="registerStudent" useGeneratedKeys = "true" keyProperty = "id">
-    INSERT INTO students(name , furigana , nickname , mail , region , age,gender,remark,isdeleted)
-    VALUES(#{name}, #{furigana}, #{nickname}, #{mail}, #{region}, #{age}, #{gender}, #{remark},false)
-  </insert>
-
-  <!--受講生コース情報を新規登録 -->
-  <insert id="registerStudentCourse" useGeneratedKeys = "true" keyProperty = "id">
-    INSERT INTO students_courses(students_id ,courses_Name , start_date , end_date)
-    VALUES(#{studentsId} , #{coursesName} , #{startDate} , #{endDate})
-  </insert>
-
-  <!--受講生を更新-->
-  <update id="updateStudent">
-    UPDATE students SET name=#{name} , furigana=#{furigana} , nickname=#{nickname} , mail=#{mail} , region=#{region},
-    age=#{age} , gender=#{gender} , remark=#{remark} , isdeleted=#{isDeleted} WHERE id=#{id}
-  </update>
-
-  <!--受講生コース情報のコース名を更新-->
-  <update id="updateStudentCourse">
-    UPDATE students_Courses SET courses_Name = #{coursesName} WHERE id = #{id}
-  </update>
 
   <!--受講生申し込み状況の全件検索-->
   <select id="searchStatusList" resultType="raisetech.student.management.data.StudentAppStatus">
@@ -62,20 +39,45 @@
   </select>
 
   <!--statusごとの検索-->
-  <select id="searchStudentAppStatus" resultType="raisetech.student.management.data.StudentAppStatus">
+  <select id="searchStudentAppStatus"
+    resultType="raisetech.student.management.data.StudentAppStatus">
     SELECT * FROM student_appstatus WHERE status= #{"status"}
   </select>
 
+  <!--受講生を新規登録 -->
+  <insert id="registerStudent" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO students(name , furigana , nickname , mail , region , age,gender,remark,isdeleted)
+    VALUES(#{name}, #{furigana}, #{nickname}, #{mail}, #{region}, #{age}, #{gender},
+    #{remark},false)
+  </insert>
+
+  <!--受講生コース情報を新規登録 -->
+  <insert id="registerStudentCourse" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO students_courses(students_id ,courses_Name , start_date , end_date)
+    VALUES(#{studentsId} , #{coursesName} , #{startDate} , #{endDate})
+  </insert>
+
   <!--受講生申し込み状況を新規登録 -->
-  <insert id="registerStudentAppStatus" useGeneratedKeys = "true" keyProperty = "id">
+  <insert id="registerStudentAppStatus" useGeneratedKeys="true" keyProperty="id">
     INSERT INTO student_appstatus(student_course_id , status)
     VALUES(#{studentCourseId}, #{status})
   </insert>
+
+  <!--受講生を更新-->
+  <update id="updateStudent">
+    UPDATE students SET name=#{name} , furigana=#{furigana} , nickname=#{nickname} , mail=#{mail} ,
+    region=#{region},
+    age=#{age} , gender=#{gender} , remark=#{remark} , isdeleted=#{isDeleted} WHERE id=#{id}
+  </update>
+
+  <!--受講生コース情報のコース名を更新-->
+  <update id="updateStudentCourse">
+    UPDATE students_Courses SET courses_Name = #{coursesName} WHERE id = #{id}
+  </update>
 
   <!--申し込み状況を更新-->
   <update id="updateStudentAppStatus">
     UPDATE student_appstatus SET status = #{status} WHERE student_course_id = #{studentCourseId}
   </update>
-
 
 </mapper>

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -93,34 +93,34 @@ class StudentControllerTest {  //これでテスト用のスプリングブー�
   void 受講生詳細の更新または論理削除が実行できること() throws Exception{
 mockMvc.perform(put("/updateStudent").contentType(MediaType.APPLICATION_JSON).content(
     """
-         {
-                     "student": {
-                         "id": 24,
-                         "name": "高瀬健",
-                         "furigana": "タカセケン",
-                         "nickname": "ケンちゃん",
-                         "mail": "ken@gmail.com",
-                         "region": "川口",
-                         "age": 56,
-                         "gender": "男",
-                         "remark": "",
-                         "deleted": false
-                     },
-                     "studentCourseList": [
-                         {
-                             "id": 13,
-                             "studentsId": 24,
-                             "coursesName": "web制作コース",
-                             "startDate": "2025-07-15T20:09:35",
-                             "endDate": "2026-07-15T20:09:35",
-                             "status": {
-                                 "id": 12,
-                                 "studentCourseId": 13,
-                                 "status": "受講終了"
-                             }
-                         }
-                     ]
-                 }
+        [
+        {
+                          "student": {
+                              "id": 2,
+                              "name": "佐藤健",
+                              "furigana": "サトウケン",
+                              "nickname": "けんけん",
+                              "mail": "sato.ken@example.com",
+                              "region": "東京都新宿区",
+                              "age": 35,
+                              "gender": "男",
+                              "remark": "",
+                              "deleted": false
+                          },
+                          "studentCourse": {
+                              "id": 4,
+                              "studentsId": 2,
+                              "coursesName": "Javaコース",
+                              "startDate": "2025-06-10T00:00:00",
+                              "endDate": "2025-09-10T00:00:00"
+                          },
+                          "studentAppStatus": {
+                              "id": 4,
+                              "studentCourseId": 4,
+                              "status": "受講終了"
+                          }
+                      }
+                      ]
         """
 ))
     .andExpect(status().isOk());

--- a/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/controller/converter/StudentConverterTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentAppStatus;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentInfo;
 import raisetech.student.management.domain.StudentDetail;
 
 class StudentConverterTest {
@@ -19,6 +20,7 @@ class StudentConverterTest {
 
   @BeforeEach
   void before(){
+
     sut = new  StudentConverter();
   }
 
@@ -72,10 +74,10 @@ class StudentConverterTest {
     studentDetails.add(studentDetail);
 
     //実行
-    List<StudentDetail> actual = sut.convertCourseStatus(studentDetails,studentAppStatusList);
+    List<StudentInfo> actual = sut.convertStudentInfo(studentDetails,studentAppStatusList);
 
     //statusが同じか確認
-    StudentAppStatus result = actual.get(0).getStudentCourseList().get(0).getStatus();
+    StudentAppStatus result = actual.get(0).getStudentAppStatus();
     assertEquals(status,result);
 
   }
@@ -95,7 +97,6 @@ class StudentConverterTest {
     studentCourse.setCoursesName("Javaコース");
     studentCourse.setStartDate(LocalDateTime.now());
     studentCourse.setEndDate(LocalDateTime.now().plusYears(1));
-    studentCourse.setStatus(studentAppStatus);
 
     List<Student> studentList = List.of(student);
     List<StudentCourse> studentCourseList = List.of(studentCourse);
@@ -147,10 +148,10 @@ class StudentConverterTest {
     StudentDetail studentDetail = new StudentDetail(student,studentCourseList);
     List<StudentDetail> studentDetails = List.of(studentDetail);
 
-    List<StudentDetail> actual = sut.convertCourseStatus(studentDetails,studentAppStatusList);
+    List<StudentInfo> actual = sut.convertStudentInfo(studentDetails,studentAppStatusList);
 
-    assertThat(actual.get(0).getStudentCourseList().get(0).getId()).isEqualTo(studentCourse.getId());
-    assertThat(actual.get(0).getStudentCourseList().get(0) .getStatus()).isNull();//コースIdが紐づかない場合はstatusはnull
+    assertThat(actual.get(0).getStudentCourse().getId()).isEqualTo(studentCourse.getId());
+    assertThat(actual.get(0).getStudentAppStatus()).isNull();//コースIdが紐づかない場合はstatusはnull
   }
 
 

--- a/src/test/java/raisetech/student/management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/StudentServiceTest.java
@@ -16,6 +16,7 @@ import raisetech.student.management.controller.converter.StudentConverter;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentAppStatus;
 import raisetech.student.management.data.StudentCourse;
+import raisetech.student.management.data.StudentInfo;
 import raisetech.student.management.domain.StudentDetail;
 import raisetech.student.management.repository.StudentRepository;
 
@@ -49,12 +50,12 @@ class StudentServiceTest {
     Mockito.when(repository.searchStatusList()).thenReturn(studentAppStatusList);
     Mockito.when(converter.convertStudentDetails(studentList,studentCourseList)).thenReturn(studentDetails);
 
-    List<StudentDetail> actual = sut.searchStudentList();
+    List<StudentInfo> actual = sut.searchStudentList();
 
     verify(repository, times(1)).search(); //repositoryのsearchを1回ちゃんと呼び出せてるか確認
     verify(repository, times(1)).searchStudentCourseList();
     verify(converter, times(1)).convertStudentDetails(studentList, studentCourseList);
-    verify(converter,times(1)).convertCourseStatus(studentDetails,studentAppStatusList);
+    verify(converter,times(1)).convertStudentInfo(studentDetails,studentAppStatusList);
 
     assertEquals(actual,studentDetails);
   }
@@ -75,7 +76,7 @@ class StudentServiceTest {
     Mockito.when(repository.searchStudentStatus(id)).thenReturn(studentAppStatus);
 
     StudentDetail expected = new StudentDetail(student,studentCourseList);
-    StudentDetail actual =  sut.searchStudent(id);
+    List<StudentInfo> actual =  sut.searchStudent(id);
 
     verify(repository,times(1)).searchStudent(id);
     verify(repository,times(1)).searchStudentCourse(id);
@@ -89,25 +90,21 @@ class StudentServiceTest {
     int id = 888;
     Student student = new Student();
     student.setId(id);
-    StudentAppStatus studentAppStatus1 = new StudentAppStatus();
-    StudentAppStatus studentAppStatus2 = new StudentAppStatus();
-    StudentCourse course1 = new StudentCourse();
-    course1.setStatus(studentAppStatus1);
-    course1.setId(999);
-    StudentCourse course2 = new StudentCourse();
-    course2.setStatus(studentAppStatus2);
-    course2.setId(777);
-    List<StudentCourse> studentCourseList = List.of(course1,course2);
+    StudentCourse studentCourse = new StudentCourse();
+    studentCourse.setId(id);
+    StudentAppStatus studentAppStatus = new StudentAppStatus();
+    studentAppStatus.setId(id);
 
-    StudentDetail studentDetail = new StudentDetail(student,studentCourseList);
+    StudentInfo studentInfo = new StudentInfo();
+    studentInfo.setStudent(student);
+    studentInfo.setStudentCourse(studentCourse);
+    studentInfo.setStudentAppStatus(studentAppStatus);
 
-    sut.registerStudent(studentDetail);
+    sut.registerStudent(studentInfo);
 
     verify(repository,times(1)).registerStudent(student);
-    verify(repository,times(1)).registerStudentCourse(course1);
-    verify(repository,times(1)).registerStudentCourse(course2);
-    verify(repository,times(1)).registerStudentAppStatus(studentAppStatus1);
-    verify(repository,times(1)).registerStudentAppStatus(studentAppStatus2);
+    verify(repository,times(1)).registerStudentCourse(studentCourse);
+    verify(repository,times(1)).registerStudentAppStatus(studentAppStatus);
 
   }
   @Test //initStudentsCourse
@@ -141,22 +138,21 @@ class StudentServiceTest {
   @Test //updateStudent
   void 受講生詳細の更新_リポジトリの処理が適切に行えていること(){
     Student student = new Student();
-    StudentCourse course1 = new StudentCourse();
+    StudentCourse studentCourse = new StudentCourse();
     StudentAppStatus studentAppStatus = new StudentAppStatus();
-    studentAppStatus.setStatus("本申し込み");
-    course1.setId(99);
-    course1.setStatus(studentAppStatus);
-    StudentCourse course2 = new StudentCourse();
-    List<StudentCourse> studentCourseList = List.of(course1,course2);
+    StudentInfo studentInfo = new StudentInfo();
+    studentInfo.setStudent(student);
+    studentInfo.setStudentCourse(studentCourse);
+    studentInfo.setStudentAppStatus(studentAppStatus);
+    List<StudentInfo>studentInfoList = new ArrayList<>();
+    studentInfoList.add(studentInfo);
 
-    StudentDetail studentDetail = new StudentDetail(student,studentCourseList);
 
-    sut.updateStudent(studentDetail);
+    sut.updateStudent(studentInfoList);
 
     verify(repository,times(1)).updateStudent(student);
-    verify(repository,times(1)).updateStudentCourse(course1);
-    verify(repository,times(1)).updateStudentCourse(course2);
-    verify(repository,times(1)).updateStudentAppStatus(course1.getStatus());
-    verify(repository,times(1)).updateStudentAppStatus(course2.getStatus());
+    verify(repository,times(1)).updateStudentCourse(studentCourse);
+    verify(repository,times(1)).updateStudentAppStatus(studentAppStatus);
+
   }
 }


### PR DESCRIPTION
## 実装内容
-申し込み情報ごとの検索機能を追加しました。
-申し込み情報のコースIDから、コース情報を検索するために”searchStudentCourseById”を追加
-コース情報から”StudentAppStatus”を削除
-１コース情報に対して、１受講生、１申し込み情報　をまとめるクラス”StudentInfo”を追加

## 工夫した点・学んだこと
- コース情報に申し込み情報を持たせていましたが、責務が混ざってしまうのと
IDで紐づけしているので持たせる必要がなかった事に気づきました。

-@GetMapping("/student")では@RequestParamを使用しました。
参考・https://tamotech.blog/2025/07/10/request-parameter/

-StudentInfoを作ったことで、全体的に受講生情報を管理しやすくなりました。
